### PR TITLE
Added cors domains to flags

### DIFF
--- a/httplistener.go
+++ b/httplistener.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/jaracil/ei"
 	. "github.com/jaracil/nexus/log"
@@ -54,8 +55,7 @@ func (*httpwsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 				wsrv.Header = make(map[string][]string)
 			}
 
-			wsrv.Header["Access-Control-Allow-Origin"] = []string{"*"}
-
+			wsrv.Header["Access-Control-Allow-Origin"] = strings.Split(opts.CorsOrigins, ",")
 			wsrv.ServeHTTP(res, req)
 
 		} else {
@@ -68,7 +68,7 @@ func (*httpwsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	} else {
 		// HTTP Bridge
 		// CORS pre-flight headers
-		res.Header().Set("Access-Control-Allow-Origin", "*")
+		res.Header().Set("Access-Control-Allow-Origin", opts.CorsOrigins)
 		res.Header().Set("Access-Control-Allow-Methods", "POST, GET")
 		res.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization")
 

--- a/options.go
+++ b/options.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"os"
-
 	"github.com/jessevdk/go-flags"
+	"os"
 )
 
 var opts struct {
+	CorsOrigins    string         `short:"o" long:"origins"  description:"List of origins to allow origins (http|https)://*.domain.com:port" default:"*"`
 	Listeners      []string       `short:"l" long:"listen"  description:"Listen on (tcp|tcp+proxy|ssl|ssl+proxy|http|https)://addr:port" default:"tcp://0.0.0.0:1717"`
 	Verbose        []bool         `short:"v" long:"verbose" description:"Show debug information. Set multiple times to increase verbosity"`
 	IsProduction   bool           `long:"production" description:"Enables Production mode (JSON output and redacted logs for login requests)"`

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 var Version = &NxVersion{
 	Major: 1,
 	Minor: 9,
-	Patch: 4,
+	Patch: 5,
 }
 
 type NxVersion struct {


### PR DESCRIPTION
#### Nuevos orígenes CORS
Añadida opción --domains/-d para establecer la lísta de orígenes CORS permitidos para realizar peticiones a Nexus (header [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin))