### PR TITLE
Added Strict-Transport-Security header

### DIFF
--- a/httplistener.go
+++ b/httplistener.go
@@ -71,7 +71,9 @@ func (*httpwsHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 		// CORS pre-flight headers
 		res.Header().Set("Access-Control-Allow-Origin", opts.CorsOrigins)
 		res.Header().Set("Access-Control-Allow-Methods", "POST, GET")
+		// res.Header().Set("Access-Control-Allow-Credentials", "true")
 		res.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization")
+		res.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
 
 		switch req.Method {
 		case "POST", "GET":

--- a/version.go
+++ b/version.go
@@ -7,7 +7,7 @@ import (
 var Version = &NxVersion{
 	Major: 1,
 	Minor: 9,
-	Patch: 6,
+	Patch: 7,
 }
 
 type NxVersion struct {


### PR DESCRIPTION
Añadido header [Strict-Transport-Security header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) para forzar que las peticiones HTTP que se realicen a nexus se hagan mediante HTTPs (al menos a partir de la primera).
Configurada directiva _preload_ para evitar que la primera conexión se haga por Http.